### PR TITLE
Untitled

### DIFF
--- a/Config/Lite.php
+++ b/Config/Lite.php
@@ -199,6 +199,26 @@ class Config_Lite implements ArrayAccess, IteratorAggregate, Countable
      */
     public function write($filename, $sectionsarray) 
     {
+        $content = $this->buildOutputString($sectionsarray);
+        if (false === file_put_contents($filename, $content, LOCK_EX)) {
+            throw new Config_Lite_Exception_Runtime(
+                sprintf(
+                    'failed to write file `%s\' for writing.', $filename
+                )
+            );
+        }
+        return true;
+    }
+
+    /**
+     * Generated the output of the ini file, suitable for echo'ing or
+     * writing back to the ini file.
+     * 
+     * @param string $sectionsarray array of ini data
+     * @return string
+     */
+    protected function buildOutputString($sectionsarray)
+    {
         $content = '';
         $sections = '';
         $globals  = '';
@@ -231,17 +251,9 @@ class Config_Lite implements ArrayAccess, IteratorAggregate, Countable
             }
             $content .= $sections;
         }
-        
-        if (false === file_put_contents($filename, $content, LOCK_EX)) {
-            throw new Config_Lite_Exception_Runtime(
-                sprintf(
-                    'failed to write file `%s\' for writing.', $filename
-                )
-            );
-        }
-        return true;
+        return $content;
     }
-    
+
     /**
      * converts type (format) to string or representable Config Format
      *
@@ -671,20 +683,7 @@ class Config_Lite implements ArrayAccess, IteratorAggregate, Countable
      */
     public function __toString() 
     {
-        $s = "";
-        if ($this->sections != null) {
-            foreach ($this->sections as $section => $name) {
-                if (is_array($name)) {
-                    $s .= sprintf("[%s]\n", $section);
-                    foreach ($name as $key => $val) {
-                        $s .= sprintf("\t%s = %s\n", $key, $val);
-                    }
-                } else {
-                    $s .= sprintf("%s=%s\n", $section, $name);
-                }
-            }
-        }
-        return $s;
+        return $this->buildOutputString($this->sections);
     }
     
     /**

--- a/tests/Config_LiteTest.php
+++ b/tests/Config_LiteTest.php
@@ -366,4 +366,11 @@ class Config_LiteTest extends PHPUnit_Framework_TestCase
         $this->config->setFilename($filename);
         $this->assertEquals($filename, $this->config->getFilename());
     }
+
+    public function testToStringMatchesWrite()
+    {
+        $this->config->setFilename($this->filename);
+        $this->config->save();
+        $this->assertEquals($this->config->__toString(), file_get_contents($this->filename));
+    }
 }


### PR DESCRIPTION
Hi Patrick,

I'm new to git/github so hopefully I am doing this right! I've made several updates to Config_Lite that I would like to propose for inclusion.
1. Add option for to ignore sections (i.e. pass false as 2nd parameter to `parse_ini_file`). Some ini files (for example, php.ini) have sections in them, but aren't actually used for anything, so it's nice to have the option to ignore them completely.
2. I removed adding the `;<?php return; ?>` in `write()` if extension is .php. File extensions are arbitrary and there can be php files that aren't .php so this just seems too arbitrary.
3. Make output via `write()` and `__toString()` match
4. Add accessor for filename.
5. Implement `Countable` interface to make it feel even more like array.

I am working on a fix for PEAR bug #18352 - would love to hear if you have any ideas about the best approach to this.

--Matthew
