### PR TITLE
Fix array check issues

### DIFF
--- a/Config/Lite.php
+++ b/Config/Lite.php
@@ -396,11 +396,11 @@ class Config_Lite implements ArrayAccess, IteratorAggregate, Countable, Serializ
         if ((null === $sec) && (null === $key) && (null === $default)) {
             return $this->sections;
         }
-        if ((null !== $sec) && array_key_exists($sec, $this->sections)
-            && isset($this->sections[$sec][$key])
-        ) {
-            return $this->sections[$sec][$key];
-        }
+	if (is_array($this->sections)) {
+		if ((null !== $sec) && array_key_exists(strval($sec), $this->sections) && isset($this->sections[$sec][$key])) {
+			return $this->sections[$sec][$key];
+		}
+	}
         // global value
         if ((null === $sec) && array_key_exists($key, $this->sections)) {
             return $this->sections[$key];
@@ -461,23 +461,24 @@ class Config_Lite implements ArrayAccess, IteratorAggregate, Countable, Serializ
                     return $this->_booleans[$value];
                 }
             }
-        }
-        if (array_key_exists($key, $this->sections[$sec])) {
-            if (empty($this->sections[$sec][$key])) {
-                return false;
-            }
-            $value = strtolower($this->sections[$sec][$key]);
-            if (!in_array($value, $this->_booleans) && (null === $default)) {
-                throw new Config_Lite_Exception_InvalidArgument(
-                    sprintf(
-                        'Not a boolean: %s, and no default value given.',
-                        $value
-                    )
-                );
-            } else {
-                return $this->_booleans[$value];
-            }
-        }
+        } else if (is_array($this->sections[strval($sec)])) {
+		if (array_key_exists($key, $this->sections[$sec])) {
+			if (empty($this->sections[$sec][$key])) {
+				return false;
+			}
+			$value = strtolower($this->sections[$sec][$key]);
+			if (!in_array($value, $this->_booleans) && (null === $default)) {
+				throw new Config_Lite_Exception_InvalidArgument(
+					sprintf(
+						'Not a boolean: %s, and no default value given.',
+						$value
+					)
+				);
+			} else {
+				return $this->_booleans[$value];
+			}
+		}
+	}
         if (null !== $default) {
             return $default;
         }


### PR DESCRIPTION
Fix issues when calling array_key_exists with a null $key or $section
value, or improperly parsed $sec value.

I noticed while examining PHP logs that I was throwing numerous errors like so:

 PHP Warning:  array_key_exists(): The first argument should be either a string or an integer in...

Adding additional checks and stringifying the value of $sec seems to stop all errors and not make anything blow up.  

