### PR TITLE
Fixes a reading crash

### DIFF
--- a/Config/Lite.php
+++ b/Config/Lite.php
@@ -201,6 +201,7 @@ class Config_Lite implements ArrayAccess, IteratorAggregate, Countable, Serializ
             return $value;
         }
         if ($this->quoteStrings) {
+	    $value = str_replace($this->delim, '\\'.$this->delim, $value);
             $value = $this->delim . $value . $this->delim;
         }
         return $value;


### PR DESCRIPTION
Fixes a reading crash when value contain the delimiter character.
Ex : Hello"World => " need to be escaped : Hello\"World